### PR TITLE
Explicitly set format of backing file

### DIFF
--- a/executor/run.py
+++ b/executor/run.py
@@ -90,6 +90,8 @@ class VM:
             # Use a Copy on Write filesystem, to avoid having to copy the whole
             # base image every time we start a VM.
             "-f", "qcow2",
+            # Explicitly set format of backing file
+            "-F", "qcow2",
             # Path of the destination image.
             str(self._path_root.resolve()),
             # New size of the disk.


### PR DESCRIPTION
QEMU deprecated the option to use a backing file without explicitly declaring its format in version 5.1, and finally removed the feature in version 6.1.

Read more: https://qemu.readthedocs.io/en/latest/about/removed-features.html#qemu-img-backing-file-without-format-removed-in-6-1