### PR TITLE
Build images in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,129 @@
+name: CI
+on:
+  pull_request: {}
+  merge_group: {}
+
+jobs:
+  build-vm:
+    name: Build image ${{ matrix.image }}-${{ matrix.arch.name }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    strategy:
+      matrix:
+        image:
+          - ubuntu
+        arch:
+          - name: x86_64
+            mode: host
+          # We have to build AArch64 in emulated mode: while there is support in GitHUb Actions for
+          # Arm runners, as of May 2025 they don't have nested virtualization enabled, preventing
+          # the use of KVM (required by the "host" mode).
+          - name: aarch64
+            mode: emul
+
+    env:
+      IMAGE_NAME: ${{ matrix.image }}
+      IMAGE_ARCH: ${{ matrix.arch.name }}
+      IMAGE_MODE: ${{ matrix.arch.mode }}
+    steps:
+      - name: Checkout the source code
+        uses: actions/checkout@v4
+
+      - name: Install Packer
+        uses: hashicorp/setup-packer@main
+
+      - name: Install QEMU
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system
+
+      # https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/
+      # Snippet authored by gsauthof.
+      - name: Enable KVM usage for the runner user
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Build the image
+        run: |
+          cd "images/${IMAGE_NAME}"
+          make "${IMAGE_ARCH}-${IMAGE_MODE}"
+
+      # Compression level 9 seems to be the one where we stop getting improvements, after trying to
+      # compress some images locally in May 2025.
+      - name: Compress the image
+        run: zstd -9 images/${IMAGE_NAME}/build/${IMAGE_NAME}-${IMAGE_ARCH}.qcow2
+
+      - name: Upload the image as an artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.image }}-${{ matrix.arch.name }}.qcow2.zst
+          path: images/${{ matrix.image }}/build/${{ matrix.image }}-${{ matrix.arch.name }}.qcow2.zst
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
+  upload:
+    name: Upload images
+    runs-on: ubuntu-latest
+    if: github.event_name == 'merge_group'
+    needs:
+      - build-vm
+
+    environment: upload
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download built images
+        uses: actions/download-artifact@v4
+        with:
+          path: images/
+          pattern: "*.qcow2.zst"
+          merge-multiple: true
+
+      - name: Authenticate with AWS
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-west-1
+          role-to-assume: arn:aws:iam::890664054962:role/gha-self-hosted-images-upload
+
+      - name: Upload images to S3
+        run: |
+          # We cannot use `aws s3 cp` since as far as I can tell it has no way to set the
+          # `if-none-match: *` header. The header is required by the IAM policy to prevent the CI
+          # credentials from overriding existing files.
+          for file in images/*; do
+            echo "uploading ${file}..."
+            aws s3api put-object \
+              --bucket rust-gha-self-hosted-images \
+              --key "images/${GITHUB_SHA}/$(basename "${file}")" \
+              --body "${file}" \
+              --if-none-match "*"
+          done
+
+      - name: Mark the current commit as the last one
+        run: |
+          echo "${GITHUB_SHA}" > latest
+          aws s3api put-object \
+            --bucket rust-gha-self-hosted-images \
+            --key latest \
+            --body latest \
+            --content-type text/plain
+
+  finish:
+    name: CI finished
+    runs-on: ubuntu-latest
+    permissions: {}
+    if: "${{ !cancelled() }}"
+    needs:
+      - build-vm
+      - upload
+    steps:
+      - name: Check if all jobs were successful or skipped
+        run: echo "${NEEDS}" | jq --exit-status 'all(.result == "success" or .result == "skipped")'
+        env:
+          NEEDS: "${{ toJson(needs) }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Packer
-        uses: hashicorp/setup-packer@main
+        uses: hashicorp/setup-packer@76e3039aa951aa4e6efe7e6ee06bc9ceb072142d
 
       - name: Install QEMU
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,11 @@ jobs:
         run: |
           cd "images/${IMAGE_NAME}"
           make "${IMAGE_ARCH}-${IMAGE_MODE}"
+        env:
+          # This token is only needed to bypass the rate limit when downloading Packer plugins. The
+          # token only has read-only access to repository contents anyway, so there is no risk
+          # passing it to Packer.
+          PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Compression level 9 seems to be the one where we stop getting improvements, after trying to
       # compress some images locally in May 2025.

--- a/images/ubuntu/Makefile
+++ b/images/ubuntu/Makefile
@@ -1,7 +1,7 @@
 ENV = PACKER_CACHE_DIR=build/cache
 PACKER_ARGS = -var "git_sha=$(shell git rev-parse HEAD)"
 
-.PHONY: host clean init x86_64-host aarch64-host
+.PHONY: host clean init x86_64-host x86_64-emul aarch64-host aarch64-emul
 
 host:
 	make $(shell uname -m)-host

--- a/images/ubuntu/Makefile
+++ b/images/ubuntu/Makefile
@@ -13,20 +13,24 @@ init:
 	$(ENV) packer init image.pkr.hcl
 
 x86_64-host: init
-	rm -rf build/x86_64
+	rm -rf build/packer-tmp
 	$(ENV) packer build $(PACKER_ARGS) -var emulated=false -var arch=x86_64 image.pkr.hcl
+	mv build/packer-tmp/rootfs.qcow2 build/ubuntu-x86_64.qcow2
 
 x86_64-emul: init
-	rm -rf build/x86_64
+	rm -rf build/packer-tmp
 	$(ENV) packer build $(PACKER_ARGS) -var emulated=true -var arch=x86_64 image.pkr.hcl
+	mv build/packer-tmp/rootfs.qcow2 build/ubuntu-x86_64.qcow2
 
 aarch64-host: init build/qemu-efi-aarch64.fd
-	rm -rf build/aarch64
+	rm -rf build/packer-tmp
 	$(ENV) packer build $(PACKER_ARGS) -var emulated=false -var arch=aarch64 -var firmware=build/qemu-efi-aarch64.fd image.pkr.hcl
+	mv build/packer-tmp/rootfs.qcow2 build/ubuntu-aarch64.qcow2
 
 aarch64-emul: init build/qemu-efi-aarch64.fd
-	rm -rf build/aarch64
+	rm -rf build/packer-tmp
 	$(ENV) packer build $(PACKER_ARGS) -var emulated=true -var arch=aarch64 -var firmware=build/qemu-efi-aarch64.fd image.pkr.hcl
+	mv build/packer-tmp/rootfs.qcow2 build/ubuntu-aarch64.qcow2
 
 # Running QEMU for AArch64 requires the QEMU_EFI.fd file to be provided. Some distributions like
 # Debian and Ubuntu package it, but the path they use is not consistent across distros. To avoid

--- a/images/ubuntu/Makefile
+++ b/images/ubuntu/Makefile
@@ -1,7 +1,7 @@
 ENV = PACKER_CACHE_DIR=build/cache
 PACKER_ARGS = -var "git_sha=$(shell git rev-parse HEAD)"
 
-.PHONY: host clean x86_64-host aarch64-host
+.PHONY: host clean init x86_64-host aarch64-host
 
 host:
 	make $(shell uname -m)-host
@@ -9,19 +9,22 @@ host:
 clean:
 	rm -rf build
 
-x86_64-host:
+init:
+	$(ENV) packer init image.pkr.hcl
+
+x86_64-host: init
 	rm -rf build/x86_64
 	$(ENV) packer build $(PACKER_ARGS) -var emulated=false -var arch=x86_64 image.pkr.hcl
 
-x86_64-emul:
+x86_64-emul: init
 	rm -rf build/x86_64
 	$(ENV) packer build $(PACKER_ARGS) -var emulated=true -var arch=x86_64 image.pkr.hcl
 
-aarch64-host: build/qemu-efi-aarch64.fd
+aarch64-host: init build/qemu-efi-aarch64.fd
 	rm -rf build/aarch64
 	$(ENV) packer build $(PACKER_ARGS) -var emulated=false -var arch=aarch64 -var firmware=build/qemu-efi-aarch64.fd image.pkr.hcl
 
-aarch64-emul: build/qemu-efi-aarch64.fd
+aarch64-emul: init build/qemu-efi-aarch64.fd
 	rm -rf build/aarch64
 	$(ENV) packer build $(PACKER_ARGS) -var emulated=true -var arch=aarch64 -var firmware=build/qemu-efi-aarch64.fd image.pkr.hcl
 

--- a/images/ubuntu/README.md
+++ b/images/ubuntu/README.md
@@ -21,8 +21,8 @@ available:
 
 | Architecture | Native build        | Emulated build      | Output path                  |
 | ------------ | ------------------- | ------------------- | ---------------------------- |
-| x86_64       | `make x86_64-host ` | `make x86_64-emul`  | `build/x86_64/rootfs.qcow2`  |
-| AArch64      | `make aarch64-host` | `make aarch64-emul` | `build/aarch64/rootfs.qcow2` |
+| x86_64       | `make x86_64-host ` | `make x86_64-emul`  | `build/ubuntu-x86_64.qcow2`  |
+| AArch64      | `make aarch64-host` | `make aarch64-emul` | `build/ubuntu-aarch64.qcow2` |
 
 ## Build process overview
 

--- a/images/ubuntu/image.pkr.hcl
+++ b/images/ubuntu/image.pkr.hcl
@@ -41,7 +41,7 @@ build {
 
 source "qemu" "ubuntu" {
   vm_name          = "rootfs.qcow2"
-  output_directory = "build/${var.arch}"
+  output_directory = "build/packer-tmp"
 
   accelerator  = var.emulated ? "tcg" : "kvm"
   machine_type = var.arch == "aarch64" ? (var.emulated ? "virt" : "virt,gic_version=3") : "pc"


### PR DESCRIPTION
This PR adds a new CI workflow that builds the images in CI and uploads them to a CDN. This will allow the executor script to just download the latest image, rather than having to build it in each self-hosted runner. The simpleinfra side [is here](https://github.com/rust-lang/simpleinfra/pull/719).

Thankfully GitHub recently enabled nested virtualization on the x86_64 Linux runners, so building the x86_64 image in CI takes around four minutes. Unfortunately nested virtualization [is not available for Arm Linux runners](https://github.com/orgs/community/discussions/148648#discussioncomment-12011562), so for those we emulate the VM on x86_64 runners, which take around half an hour to build. I don't expect to have too much development in this repository, so the 30 minute CI time shouldn't be *too* painful.

This PR is best reviewed commit-by-commit.
Fixes #11 