### PR TITLE
Upload `.sha256` files for each image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,14 @@ jobs:
               --key "images/${GITHUB_SHA}/$(basename "${file}")" \
               --body "${file}" \
               --if-none-match "*"
+            echo "calculating hash of ${file}..."
+            sha256sum "${file}" | cut -d ' ' -f 1 > hash
+            echo "uploading ${file}.sha256..."
+            aws s3api put-object \
+              --bucket rust-gha-self-hosted-images \
+              --key "images/${GITHUB_SHA}/$(basename "${file}").sha256" \
+              --body "hash" \
+              --if-none-match "*"
           done
 
       - name: Mark the current commit as the last one


### PR DESCRIPTION
This PR changes CI to upload a `.sha256` file along with each uploaded image. This will let the executor script verify that a local cache was not tampered with (without having to re-download the whole image).