### PR TITLE
Calculate the hash of the uncompressed image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,11 @@ jobs:
       - name: Compress the image
         run: zstd -9 images/${IMAGE_NAME}/build/${IMAGE_NAME}-${IMAGE_ARCH}.qcow2
 
+      - name: Hash the image
+        run: |
+          file="images/${IMAGE_NAME}/build/${IMAGE_NAME}-${IMAGE_ARCH}.qcow2"
+          sha256sum "${file}" | cut -d ' ' -f 1 > "${file}.sha256"
+
       - name: Upload the image as an artifact
         uses: actions/upload-artifact@v4
         with:
@@ -70,6 +75,14 @@ jobs:
           if-no-files-found: error
           retention-days: 1
           compression-level: 0
+
+      - name: Upload the hash as an artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.image }}-${{ matrix.arch.name }}.qcow2.sha256
+          path: images/${{ matrix.image }}/build/${{ matrix.image }}-${{ matrix.arch.name }}.qcow2.sha256
+          if-no-files-found: error
+          retention-days: 1
 
   upload:
     name: Upload images
@@ -87,7 +100,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: images/
-          pattern: "*.qcow2.zst"
+          pattern: "*.qcow2.*"
           merge-multiple: true
 
       - name: Authenticate with AWS
@@ -107,14 +120,6 @@ jobs:
               --bucket rust-gha-self-hosted-images \
               --key "images/${GITHUB_SHA}/$(basename "${file}")" \
               --body "${file}" \
-              --if-none-match "*"
-            echo "calculating hash of ${file}..."
-            sha256sum "${file}" | cut -d ' ' -f 1 > hash
-            echo "uploading ${file}.sha256..."
-            aws s3api put-object \
-              --bucket rust-gha-self-hosted-images \
-              --key "images/${GITHUB_SHA}/$(basename "${file}").sha256" \
-              --body "hash" \
               --if-none-match "*"
           done
 


### PR DESCRIPTION
While developing the changes for the executor, I noticed it would be more helpful to hash the uncompressed image rather than the compressed image. This PR updates CI to upload the correct hash.