### PR TITLE
Add `--no-shutdown-after-job` to help debugging

### DIFF
--- a/executor/README.md
+++ b/executor/README.md
@@ -24,6 +24,9 @@ The `./run.py` script accepts the following command-line arguments:
 * **`--images-cache-dir`**: the directory to cache downloaded VM images in. If
   it's not provided, no images will be cached. Note that a cache must not be
   accessed by multiple instances of the executor concurrently.
+* **`--no-shutdown-after-job`**: ask the VM to not shut down after executing a
+  job. See ["Troubleshooting the VM immediately
+  exiting"](#troubleshooting-the-vm-immediately-exiting).
 * **`--ssh-port`**: host port to bind the VM's SSH port into. If it's not
   provided, the VM's SSH server will not be accessible from the host.
 
@@ -121,6 +124,17 @@ available on the images server. If a new one is available, and there is no job
 currently running on the VM, the executor will gracefully shut down the VM and
 exit. It's then the responsibility of the init system to restart the executor,
 which will pick the new image.
+
+## Troubleshooting the VM immediately exiting
+
+The [Ubuntu images][ubuntu-readme] are configured to shut down as soon as the
+GitHub Actions runner exits. This can result in the VM shutting down as soon as
+it boots when the runner fails to start, preventing you from logging into the VM
+and debugging the failure.
+
+When that happens, you should pass the `--no-shutdown-after-job` CLI flag to
+`run.py`. Doing so will set the `gha-inhibit-shutdown` [systemd credential],
+which tells the image to not shutdown after the GitHub Actions runner exits.
 
 [runner-group]: https://docs.github.com/en/enterprise-cloud@latest/actions/how-tos/hosting-your-own-runners/managing-self-hosted-runners/managing-access-to-self-hosted-runners-using-groups
 [images-prod]: https://gha-self-hosted-images.infra.rust-lang.org

--- a/executor/run.py
+++ b/executor/run.py
@@ -82,6 +82,12 @@ def main():
     )
 
     parser.add_argument(
+        "--no-shutdown-after-job",
+        help="Ask the VM not to shutdown after completing a GitHub Actions job",
+        action="store_true",
+    )
+
+    parser.add_argument(
         "--ssh-port",
         help="Port to bind the SSH server to",
         type=int,

--- a/images/ubuntu/README.md
+++ b/images/ubuntu/README.md
@@ -100,7 +100,9 @@ Each time it boots, the VM will:
   `files/start-gha-runner.py`).
 
 The GitHub Actions runner will then listen for jobs, and execute a single job,
-once the job finishes, the runner will shut down the VM.
+once the job finishes, the runner will shut down the VM. The shutdown can be
+inhibited by setting the `gha-inhibit-shutdown` [systemd credentials] (useful
+when debugging runner failures).
 
 The VM provides passwordless sudo access via SSH through the `manage` user
 (password: `password`).

--- a/images/ubuntu/files/gha-runner.service
+++ b/images/ubuntu/files/gha-runner.service
@@ -9,8 +9,10 @@ After=network.target
 ExecStart=/bin/sh -c './run.sh --jitconfig "$(cat ${CREDENTIALS_DIRECTORY}/gha-jitconfig)"'
 LoadCredential=gha-jitconfig
 
-# Power off the system when a CI run finishes.
-ExecStopPost=/usr/bin/sudo /usr/bin/systemctl poweroff
+# Power off the system when a CI run finishes. If the gha-inhibit-shutdown systemd credential
+# (https://systemd.io/CREDENTIALS/) is set, the shutdown will not happen.
+ExecStopPost=/bin/sh -c '[ -f "${CREDENTIALS_DIRECTORY}/gha-inhibit-shutdown" ] || /usr/bin/sudo /usr/bin/systemctl poweroff'
+LoadCredential=gha-inhibit-shutdown
 
 User=gha
 Group=gha


### PR DESCRIPTION
I'm trying to debug the runner failing to start, and the VM immediately shutting down doesn't exactly help with debugging. This PR adds a CLI flag to ask the VM not to shutdown, and some troubleshooting instructions.