### PR TITLE
Pass the just-in-time token through an HTTP server

### DIFF
--- a/executor/README.md
+++ b/executor/README.md
@@ -101,9 +101,10 @@ Note that you will need to restart the script if you change any image, as
 ## Runtime behavior of the executor
 
 The executor script will use the GitHub credentials to generate a [just-in-time
-registration token][jit] and pass it to the VM in the `gha-jitconfig` [systemd
-credential]. It will then start the VM with QEMU, and assume the image will
-start a GitHub Actions runner with the token passed into it.
+registration token][jit] and start a secured HTTP server providing that token to
+the future VM. It will then start the VM with QEMU, passing to it the URL of the
+HTTP server in the `gha-jitconfig-url` [systemd credential], and assume the
+image will start a GitHub Actions runner with the token passed into it.
 
 The executor will periodically poll the GitHub API to determine when the runner
 starts executing a job. When that happens, it will start a timer (as defined in

--- a/executor/executor/http_server.py
+++ b/executor/executor/http_server.py
@@ -1,0 +1,84 @@
+# Create a single-use HTTP server to inject a credential into the VM.
+#
+# Our self-hosted runners setup relies on systemd credentials to inject parameters and secrets into
+# the running VM. In August 2025 we discovered a bug though: when a credential was too long, systemd
+# would truncate it when loading it. This was a systemd problem, as with `dmidecode -t 11` we could
+# clearly see the credential was passed in the VM untruncated.
+#
+# Some credentials (like just-in-time runner configurations) are fairly long, and given that bug we
+# cannot pass them to the VM with systemd. To work around that, this module spawns an HTTP server
+# returning the actual credential, and inject its URL into the VM with a systemd credential.
+#
+# To ensure other processes running on the system cannot easily grab the credential too, the server:
+#
+# - Listens to a random, unpredictable port.
+# - Only serves the credential when a long, random authorization token is included in the URL.
+# - Locks itself up after the credential has been retrieved, preventing further retrievals.
+
+from .utils import log
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from tempfile import NamedTemporaryFile
+from threading import Thread
+import secrets
+
+
+# IP of the host machine in QEMU-based VMs, under the default settings.
+GUEST_IP = "10.0.2.2"
+
+
+class CredentialServer:
+    def __init__(self, name, value):
+        token = secrets.token_urlsafe(64)
+        already_requested = False
+
+        class ServerHandler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                # The nonlocal keyword binds to the variable in the outer scope.
+                nonlocal already_requested
+
+                if self.path.lstrip("/") != token:
+                    log(
+                        f"warning: attempted to retrieve credential {name} with invalid token"
+                    )
+                    self._respond(403, "error: invalid token")
+                elif already_requested:
+                    log(
+                        f"warning: attempted to retrieve credential {name} multiple times"
+                    )
+                    self._respond(400, "error: credential already requested")
+                else:
+                    log(f"credential {name} retrieved through the HTTP server")
+                    self._respond(200, value)
+
+                    # Only allow the credential to be retrieved once.
+                    already_requested = True
+
+            def _respond(self, code, message):
+                self.send_response(code)
+                self.send_header("Content-type", "text/plain")
+                self.end_headers()
+                self.wfile.write(message.encode("utf-8") + b"\n")
+
+            def log_message(*args, **kwargs):
+                # Suppress the builtin logging, we do our own logging.
+                pass
+
+        server = HTTPServer(("127.0.0.1", 0), ServerHandler)
+
+        self._port = server.server_port
+        self._name = name
+        self._token = token
+
+        thread = Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+
+    def configure_qemu(self, qemu):
+        # The URL is saved into a file rather than passing it directly as a CLI argument to avoid it
+        # leaking through the command line arguments.
+        self._url_file = NamedTemporaryFile("w")
+        self._url_file.write(
+            f"io.systemd.credential:{self._name}=http://{GUEST_IP}:{self._port}/{self._token}"
+        )
+        self._url_file.flush()
+
+        qemu.smbios_11.append(f"path={self._url_file.name}")

--- a/executor/executor/qemu.py
+++ b/executor/executor/qemu.py
@@ -1,3 +1,4 @@
+from executor.http_server import CredentialServer
 from .github import GitHubRunnerStatusWatcher
 from .qmp import QMPClient
 from .utils import log, Timer
@@ -119,10 +120,8 @@ class VM:
         if self._cli.no_shutdown_after_job:
             qemu.smbios_11.append("value=io.systemd.credential:gha-inhibit-shutdown=1")
 
-        # Pass the jitconfig to the runner using systemd credentials.
-        qemu.smbios_11.append(
-            f"value=io.systemd.credential:gha-jitconfig={self._runner.jitconfig}",
-        )
+        jitconfig = CredentialServer("gha-jitconfig-url", self._runner.jitconfig)
+        jitconfig.configure_qemu(qemu)
 
         log("starting the virtual machine")
         self._process = qemu.spawn()

--- a/executor/executor/qemu.py
+++ b/executor/executor/qemu.py
@@ -1,6 +1,9 @@
 from .github import GitHubRunnerStatusWatcher
 from .qmp import QMPClient
 from .utils import log, Timer
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
 import os
 import pathlib
 import shutil
@@ -15,23 +18,18 @@ GRACEFUL_SHUTDOWN_TIMEOUT = 60
 # Architecture-specific QEMU flags and BIOS blob URL.
 QEMU_ARCH = {
     "x86_64": {
-        "flags": [
-            # Standard x86_64 machine with hardware acceleration.
-            "-machine",
-            "pc,accel=kvm",
-        ],
+        "bios": None,
+        "cpu_model": None,
+        # Standard x86_64 machine with hardware acceleration.
+        "machine": "pc,accel=kvm",
     },
     "aarch64": {
-        "flags": [
-            # Virtual AArch64 machine with hardware acceleration.
-            "-machine",
-            "virt,gic_version=3,accel=kvm",
-            # Use the host's CPU variant.
-            "-cpu",
-            "host",
-        ],
         # Installed with `sudo apt-get install qemu-efi-aarch64`
         "bios": "/usr/share/qemu-efi-aarch64/QEMU_EFI.fd",
+        # Use the host's CPU variant.
+        "cpu_model": "host",
+        # Virtual AArch64 machine with hardware acceleration.
+        "machine": "virt,gic_version=3,accel=kvm",
     },
 }
 
@@ -97,65 +95,37 @@ class VM:
         if self._process is not None:
             raise RuntimeError("this VM was already started")
 
-        def preexec_fn():
-            # Don't forward signals to QEMU
-            os.setpgrp()
+        qemu = QemuInvocation(
+            cpu_cores=self._cpu,
+            memory=self._ram,
+            drive=f"file={self._path_root},media=disk,if=virtio",
+            bios=QEMU_ARCH[self._arch]["bios"],
+            cpu_model=QEMU_ARCH[self._arch]["cpu_model"],
+            machine=QEMU_ARCH[self._arch]["machine"],
+            qemu_binary=f"qemu-system-{self._arch}",
+        )
 
-        cmd = [
-            f"qemu-system-{self._arch}",
-            # Reserved RAM for the virtual machine.
-            "-m",
-            str(self._ram),
-            # Allocated cores for the virtual machine.
-            "-smp",
-            str(self._cpu),
-            # Prevent QEMU from showing a graphical console window.
-            "-display",
-            "none",
-            # Mount the VM image as the root drive.
-            "-drive",
-            "file=" + str(self._path_root) + ",media=disk,if=virtio",
-            # Enable networking inside the VM.
-            "-net",
-            "nic,model=virtio",
-            # This QMP port is used by the shutdown() method to send the
-            # shutdown signal to the QEMU VM instead of killing it.
-            "-qmp",
-            "unix:" + str(self._qmp_shutdown_path) + ",server,nowait",
-        ]
-        cmd += QEMU_ARCH[self._arch]["flags"]
+        # This QMP port is used by the shutdown() method to send the
+        # shutdown signal to the QEMU VM instead of killing it.
+        qemu.qmp_sockets.append(self._qmp_shutdown_path)
 
-        net_extra_params = []
         if self._cli.ssh_port is not None:
             # We only bind to SSH when a port is requested.
-            net_extra_params.append(f"hostfwd=tcp:127.0.0.1:{self._cli.ssh_port}-:22")
-        cmd += ["-net", "user" + "".join(f",{param}" for param in net_extra_params)]
-
-        if "bios" in QEMU_ARCH[self._arch]:
-            cmd += ["-bios", QEMU_ARCH[self._arch]["bios"]]
-
-        smbios_11_params = []
+            qemu.net_user.append(f"hostfwd=tcp:127.0.0.1:{self._cli.ssh_port}-:22")
 
         # Pass the credential asking the runner not to shutdown. This is the first credential we add
         # because it has to be passed to the VM even if the following credentials get truncated or
         # similar (as this credential is used for debugging).
         if self._cli.no_shutdown_after_job:
-            smbios_11_params.append(
-                "value=io.systemd.credential:gha-inhibit-shutdown=1"
-            )
+            qemu.smbios_11.append("value=io.systemd.credential:gha-inhibit-shutdown=1")
 
         # Pass the jitconfig to the runner using systemd credentials.
-        smbios_11_params.append(
+        qemu.smbios_11.append(
             f"value=io.systemd.credential:gha-jitconfig={self._runner.jitconfig}",
         )
 
-        cmd += [
-            "-smbios",
-            f"type=11,{','.join(smbios_11_params)}",
-        ]
-
         log("starting the virtual machine")
-        self._process = subprocess.Popen(cmd, preexec_fn=preexec_fn)
+        self._process = qemu.spawn()
 
         if self._cli.ssh_port is not None:
             print()
@@ -226,3 +196,62 @@ class VM:
     def _gha_build_started(self):
         self._prevent_external_shutdowns = True
         Timer("vm-timeout", self._shutdown, self._vm_timeout).start()
+
+
+@dataclass
+class QemuInvocation:
+    bios: Optional[str]
+    cpu_cores: int
+    cpu_model: Optional[str]
+    drive: str
+    machine: str
+    memory: int
+    qemu_binary: str
+
+    qmp_sockets: List[Path] = field(default_factory=list)
+    net_user: List[str] = field(default_factory=list)
+    smbios_11: List[str] = field(default_factory=list)
+
+    def spawn(self) -> subprocess.Popen:
+        def preexec_fn():
+            # Don't forward signals to QEMU
+            os.setpgrp()
+
+        cmd = [
+            self.qemu_binary,
+            # Machine to emulate.
+            "-machine",
+            self.machine,
+            # Reserved RAM for the virtual machine.
+            "-m",
+            str(self.memory),
+            # Allocated cores for the virtual machine.
+            "-smp",
+            str(self.cpu_cores),
+            # Prevent QEMU from showing a graphical console window.
+            "-display",
+            "none",
+            # Mount the VM image as the root drive.
+            "-drive",
+            self.drive,
+            # Enable networking inside the VM.
+            "-net",
+            "nic,model=virtio",
+            # Port forwarding configuration.
+            "-net",
+            "user" + "".join(f",{param}" for param in self.net_user),
+        ]
+
+        if self.cpu_model is not None:
+            cmd += ["-cpu", self.cpu_model]
+
+        if self.bios is not None:
+            cmd += ["-bios", self.bios]
+
+        for socket in self.qmp_sockets:
+            cmd += ["-qmp", f"unix:{socket},server,nowait"]
+
+        for param in self.smbios_11:
+            cmd += ["-smbios", f"type=11,{param}"]
+
+        return subprocess.Popen(cmd, preexec_fn=preexec_fn)

--- a/images/ubuntu/files/gha-runner.service
+++ b/images/ubuntu/files/gha-runner.service
@@ -3,11 +3,12 @@ Description=GitHub Actions Runner
 After=network.target
 
 [Service]
-# Start the runner using just-in-time configuration. The jitconfig is loaded using systemd's
-# credentials management (https://systemd.io/CREDENTIALS/), which allows it to be set by the
-# hypervisor with a single command-line flag.
-ExecStart=/bin/sh -c './run.sh --jitconfig "$(cat ${CREDENTIALS_DIRECTORY}/gha-jitconfig)"'
-LoadCredential=gha-jitconfig
+# Start the runner using just-in-time configuration. The jitconfig is loaded from a temporary HTTP
+# server spawned in the host, whose URL is passed to the VM using systemd's credentials management
+# (https://systemd.io/CREDENTIALS/). This allows the URL to be set by the hypervisor with a single
+# command-line flag.
+ExecStart=/bin/sh -c './run.sh --jitconfig "$(curl --fail $(cat ${CREDENTIALS_DIRECTORY}/gha-jitconfig-url))"'
+LoadCredential=gha-jitconfig-url
 
 # Power off the system when a CI run finishes. If the gha-inhibit-shutdown systemd credential
 # (https://systemd.io/CREDENTIALS/) is set, the shutdown will not happen.


### PR DESCRIPTION
While the whole setup was working fine at the start of July, when I started trying to run it on the old perf server I noticed the VM would immediately shut down. After debugging it with #35, I discovered the shutdown was caused by the runner failing to start, and it failed to start because the jitconfig passed to the runner through systemd credentials was truncated.

I am not sure exactly *why* systemd credentials started getting truncated, but the truncation only happens with really long credentials. To avoid the issue, the executor now spawns an HTTP server serving the jitconfig, and passes with a systemd credential the URL of that server into the VM. The server has a few security thingies documented in its comments.

Tested locally and everything works. I need the PR to be merged before I can try this again on the perf server, as I need the new image to be built. This PR is best reviewed commit-by-commit.