### PR TITLE
Install Rust in the CI image

### DIFF
--- a/images/ubuntu/image.pkr.hcl
+++ b/images/ubuntu/image.pkr.hcl
@@ -30,6 +30,7 @@ build {
       "./scripts/install-packages.sh",
       "./scripts/install-gha-runner.sh",
       "./scripts/install-awscli.sh",
+      "./scripts/install-rust.sh",
       "./scripts/setup-ssh.sh",
       "./scripts/setup-disk-resize.sh",
       "./scripts/setup-grub.sh",

--- a/images/ubuntu/scripts/install-rust.sh
+++ b/images/ubuntu/scripts/install-rust.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+# CI expects a Rust toolchain to be installed.
+DEBIAN_FRONTEND=noninteractive sudo apt install rustup -y
+sudo -u gha rustup toolchain install stable --profile minimal


### PR DESCRIPTION
Discovered in https://github.com/rust-lang/rust/pull/144859 that we now build citool, which requires Rust to be installed on the CI VM.