### PR TITLE
Fix artifact name for gha-vm binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,11 +118,16 @@ jobs:
         env:
           target: ${{ matrix.target.tuple }}
 
+      - name: Rename the binary before upload
+        run: mv executor/target/$target/release/gha-vm /tmp/gha-vm-$target
+        env:
+          target: ${{ matrix.target.tuple }}
+
       - name: Upload the executor as an artifact
         uses: actions/upload-artifact@v4
         with:
           name: gha-vm-${{ matrix.target.tuple }}
-          path: executor/target/${{ matrix.target.tuple }}/release/gha-vm
+          path: /tmp/gha-vm-${{ matrix.target.tuple }}
           if-no-files-found: error
           retention-days: 1
 


### PR DESCRIPTION
I was working on the Ansible configuration for the self-hosted runners, and run into a puzzling failure: the workflow was supposed to upload pre-built binaries to `executor/$commit/gha-vm-$target`, but in practice it was uploading it to `executor/$commit/gha-vm` (uploading only one of the two binaries).

At the start I was puzzled, because the IAM policy for the workflow forbids overriding existing files, but turns out this is a GitHub Actions problem: when you set the `name:` in the artifact upload action, that just sets the name of the archive, it doesn't rename the file provided in `path:`. We were thus uploading two artifacts containing a binary called `gha-vm`, with one overriding the other.

This PR fixes it by renaming the file before uploading the artifact.